### PR TITLE
Fix for markdown confusing link with image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # ZLinky_TIC
  Téléinformation Linky autoalimenté communiquant en ZigBee 3.0  
  vous pouvez vous procurer le ZLinky_TIC à l'adresse suivante :  
- ![Boutique LiXee](https://lixee.fr/)
+ [Boutique LiXee](https://lixee.fr/)
  
 
 ## Description


### PR DESCRIPTION
Le lien boutique n'était pas clickable, le markdown spécifiait un code d'image `![alt text](url)` au lieu d'un lien `[link text](url)`